### PR TITLE
Issue # 10 Prevent user from adding duplicate or empty item to the list

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -70,7 +70,7 @@ export function App() {
 						/>
 						<Route
 							path="/manage-list"
-							element={<ManageList listPath={listPath} />}
+							element={<ManageList listPath={listPath} data={data || []} />}
 						/>
 					</Route>
 

--- a/src/components/forms/AddItemForm.tsx
+++ b/src/components/forms/AddItemForm.tsx
@@ -45,7 +45,7 @@ export function AddItemForm({ listPath }: Props) {
 		const validItemName = validateItemString(itemName);
 
 		if (!validItemName) {
-			toast.error("Item name cannot be empty.");
+			toast.error("Please enter a valid item name.");
 			return;
 		}
 
@@ -66,10 +66,10 @@ export function AddItemForm({ listPath }: Props) {
 					success: () => {
 						setItemName("");
 						setItemNextPurchaseTimeline(PurchaseTime.soon);
-						return `${itemName} successfully added to your list!`;
+						return `${validItemName} successfully added to your list!`;
 					},
 					error: () => {
-						return `${itemName} failed to add to your list. Please try again!`;
+						return `${validItemName} failed to add to your list. Please try again!`;
 					},
 				},
 			);

--- a/src/components/forms/AddItemForm.tsx
+++ b/src/components/forms/AddItemForm.tsx
@@ -44,10 +44,11 @@ export function AddItemForm({ listPath, data: unfilteredListItems }: Props) {
 	) => {
 		e.preventDefault();
 
-		const validItemName = validateItemString(itemName, unfilteredListItems);
+		// Validate the item name
+		const validationError = validateItemString(itemName, unfilteredListItems);
 
-		if (!validItemName) {
-			toast.error("Please enter a valid item name.");
+		if (validationError) {
+			toast.error(validationError);
 			return;
 		}
 
@@ -60,25 +61,20 @@ export function AddItemForm({ listPath, data: unfilteredListItems }: Props) {
 
 		const daysUntilNextPurchase = purchaseTimelines[itemNextPurchaseTimeline];
 
-		if (validItemName) {
-			try {
-				await toast.promise(
-					addItem(listPath, validItemName, daysUntilNextPurchase),
-					{
-						loading: "Adding item to list.",
-						success: () => {
-							setItemName("");
-							setItemNextPurchaseTimeline(PurchaseTime.soon);
-							return `${validItemName} successfully added to your list!`;
-						},
-						error: () => {
-							return `${validItemName} failed to add to your list. Please try again!`;
-						},
-					},
-				);
-			} catch (error) {
-				console.error("Failed to add item:", error);
-			}
+		try {
+			await toast.promise(addItem(listPath, itemName, daysUntilNextPurchase), {
+				loading: "Adding item to list.",
+				success: () => {
+					setItemName("");
+					setItemNextPurchaseTimeline(PurchaseTime.soon);
+					return `${itemName} successfully added to your list!`;
+				},
+				error: () => {
+					return `${itemName} failed to add to your list. Please try again!`;
+				},
+			});
+		} catch (error) {
+			console.error("Failed to add item:", error);
 		}
 	};
 

--- a/src/components/forms/AddItemForm.tsx
+++ b/src/components/forms/AddItemForm.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, FormEvent, useState } from "react";
 import { addItem } from "../../api";
-import { validateTrimmedString } from "../../utils";
+import { validateItemString } from "../../utils";
 import toast from "react-hot-toast";
 
 import { useNavigate } from "react-router-dom";
@@ -42,12 +42,10 @@ export function AddItemForm({ listPath }: Props) {
 		listPath: string,
 	) => {
 		e.preventDefault();
-		const trimmedItemName = validateTrimmedString(itemName);
+		const validItemName = validateItemString(itemName);
 
-		if (!trimmedItemName) {
-			toast.error(
-				"Item name cannot be empty or just spaces. Please enter a valid name.",
-			);
+		if (!validItemName) {
+			toast.error("Item name cannot be empty.");
 			return;
 		}
 
@@ -62,7 +60,7 @@ export function AddItemForm({ listPath }: Props) {
 
 		try {
 			await toast.promise(
-				addItem(listPath, trimmedItemName, daysUntilNextPurchase),
+				addItem(listPath, validItemName, daysUntilNextPurchase),
 				{
 					loading: "Adding item to list.",
 					success: () => {
@@ -98,7 +96,6 @@ export function AddItemForm({ listPath }: Props) {
 								name="item"
 								value={itemName}
 								onChange={handleItemNameTextChange}
-								required
 								aria-label="Enter the item name"
 								aria-required
 							/>

--- a/src/components/forms/AddItemForm.tsx
+++ b/src/components/forms/AddItemForm.tsx
@@ -62,22 +62,24 @@ export function AddItemForm({ listPath, data: unfilteredListItems }: Props) {
 		const daysUntilNextPurchase = purchaseTimelines[itemNextPurchaseTimeline];
 
 		try {
-			await toast.promise(addItem(listPath, itemName, daysUntilNextPurchase), {
-				loading: "Adding item to list.",
-				success: () => {
-					setItemName("");
-					setItemNextPurchaseTimeline(PurchaseTime.soon);
-					return `${itemName} successfully added to your list!`;
+			await toast.promise(
+				addItem(listPath, itemName, daysUntilNextPurchase), // saving original input
+				{
+					loading: "Adding item to list.",
+					success: () => {
+						setItemName("");
+						setItemNextPurchaseTimeline(PurchaseTime.soon);
+						return `${itemName} successfully added to your list!`; // showing original input
+					},
+					error: () => {
+						return `${itemName} failed to add to your list. Please try again!`;
+					},
 				},
-				error: () => {
-					return `${itemName} failed to add to your list. Please try again!`;
-				},
-			});
+			);
 		} catch (error) {
 			console.error("Failed to add item:", error);
 		}
 	};
-
 	const navigateToListPage = () => {
 		navigate("/list");
 	};

--- a/src/components/forms/AddItemForm.tsx
+++ b/src/components/forms/AddItemForm.tsx
@@ -1,6 +1,6 @@
 import { ChangeEvent, FormEvent, useState } from "react";
 import { addItem, ListItem } from "../../api";
-import { validateItemString } from "../../utils";
+import { validateItemName } from "../../utils";
 import toast from "react-hot-toast";
 
 import { useNavigate } from "react-router-dom";
@@ -44,11 +44,15 @@ export function AddItemForm({ listPath, data: unfilteredListItems }: Props) {
 	) => {
 		e.preventDefault();
 
-		// Validate the item name
-		const validationError = validateItemString(itemName, unfilteredListItems);
+		// Validate the item name input
+		const validationErrorMessage = validateItemName(
+			itemName,
+			unfilteredListItems,
+		);
 
-		if (validationError) {
-			toast.error(validationError);
+		// If there's a validation error, show the error and return early
+		if (validationErrorMessage) {
+			toast.error(validationErrorMessage);
 			return;
 		}
 

--- a/src/utils/validateTrimmedString.ts
+++ b/src/utils/validateTrimmedString.ts
@@ -13,9 +13,11 @@ export function validateItemName(
 	}
 
 	//Remove punctuation marks and normalize input
-	const punctuationRegex = /[^a-z0-9]/g;
+	const punctuationRegex = /[^\p{L}]/gu;
 
-	const normalizedInputName = input.toLowerCase().replace(/[^a-z0-9]/g, "");
+	const normalizedInputName = trimmedInput
+		.replace(punctuationRegex, "")
+		.toLowerCase();
 
 	//Create a list of  normalized existing item names
 	const normalizedExistingItemNames = existingItems.map((existingItem) => {

--- a/src/utils/validateTrimmedString.ts
+++ b/src/utils/validateTrimmedString.ts
@@ -13,11 +13,9 @@ export function validateItemName(
 	}
 
 	//Remove punctuation marks and normalize input
-	const punctuationRegex = /[^\p{L}]/gu;
+	const punctuationRegex = /[^a-z0-9]/g;
 
-	const normalizedInputName = trimmedInput
-		.replace(punctuationRegex, "")
-		.toLowerCase();
+	const normalizedInputName = input.toLowerCase().replace(/[^a-z0-9]/g, "");
 
 	//Create a list of  normalized existing item names
 	const normalizedExistingItemNames = existingItems.map((existingItem) => {

--- a/src/utils/validateTrimmedString.ts
+++ b/src/utils/validateTrimmedString.ts
@@ -33,7 +33,7 @@ export function validateItemName(
 
 	//return error if the item already exists
 	if (isDuplicateItem(normalizedInputName)) {
-		return "Item already exists in the list.";
+		return ` ${normalizedInputName} already exists in the list`;
 	}
 
 	// Return null if no errors are found (input is valid)

--- a/src/utils/validateTrimmedString.ts
+++ b/src/utils/validateTrimmedString.ts
@@ -1,10 +1,16 @@
 // makes sure the string passed into the function isn't an empty string
-export function validateTrimmedString(input: string) {
-	const trimmedInput = input.trim();
+export function validateItemString(input: string) {
+	const trimmedInput = input.trim(); //removes leading and trailing whitespaces
 
+	// Condition 1: Check if the input is empty
 	if (trimmedInput.length === 0) {
 		return null;
 	}
 
-	return trimmedInput;
+	const removedPunctuation = /[^\p{L}]/gu;
+
+	const validatedString = trimmedInput.replace(removedPunctuation, "");
+	console.log(validatedString);
+
+	return validatedString;
 }

--- a/src/utils/validateTrimmedString.ts
+++ b/src/utils/validateTrimmedString.ts
@@ -10,7 +10,6 @@ export function validateItemString(input: string) {
 	const removedPunctuation = /[^\p{L}]/gu;
 
 	const validatedString = trimmedInput.replace(removedPunctuation, "");
-	console.log(validatedString);
 
-	return validatedString;
+	return validatedString.length > 0 ? validatedString : null;
 }

--- a/src/utils/validateTrimmedString.ts
+++ b/src/utils/validateTrimmedString.ts
@@ -13,7 +13,7 @@ export function validateItemName(
 	}
 
 	//Remove punctuation marks and normalize input
-	const punctuationRegex = /[^\p{L}\s]/gu;
+	const punctuationRegex = /[^\p{L}]/gu;
 
 	const normalizedInputName = trimmedInput
 		.replace(punctuationRegex, "")

--- a/src/utils/validateTrimmedString.ts
+++ b/src/utils/validateTrimmedString.ts
@@ -1,5 +1,10 @@
+import { ListItem } from "../api";
+
 // makes sure the string passed into the function isn't an empty string
-export function validateItemString(input: string) {
+export function validateItemString(
+	input: string,
+	itemList: ListItem[] = [],
+): string | null {
 	const trimmedInput = input.trim(); //removes leading and trailing whitespaces
 
 	// Condition 1: Check if the input is empty
@@ -7,9 +12,29 @@ export function validateItemString(input: string) {
 		return null;
 	}
 
-	const removedPunctuation = /[^\p{L}]/gu;
+	//Remove punctuation marks and normalize input
+	const removedPunctuation = /[^\p{L}\s]/gu;
 
-	const validatedString = trimmedInput.replace(removedPunctuation, "");
+	const validatedString = trimmedInput
+		.replace(removedPunctuation, "")
+		.toLowerCase();
 
-	return validatedString.length > 0 ? validatedString : null;
+	//Create a normalized list of items already present in the list
+	const normalizedItemNames = itemList.map((listItem) => {
+		return listItem.name.replace(removedPunctuation, "").toLowerCase();
+	});
+
+	//Condition 2: check each item from the normalized list against the normalized input for duplicates
+	const isItemOnList = (validatedString: string): boolean => {
+		return normalizedItemNames.some(
+			(item) => item.toLowerCase() === validatedString.toLowerCase(),
+		);
+	};
+
+	//return validatedString input if no duplicates found
+	if (isItemOnList(validatedString)) {
+		throw new Error("Item already exists");
+	} else {
+		return validatedString;
+	}
 }

--- a/src/utils/validateTrimmedString.ts
+++ b/src/utils/validateTrimmedString.ts
@@ -3,13 +3,13 @@ import { ListItem } from "../api";
 // makes sure the string passed into the function isn't an empty string
 export function validateItemString(
 	input: string,
-	itemList: ListItem[] = [],
+	itemList: ListItem[],
 ): string | null {
 	const trimmedInput = input.trim(); //removes leading and trailing whitespaces
 
 	// Condition 1: Check if the input is empty
 	if (trimmedInput.length === 0) {
-		return null;
+		return "Item cannot be empty";
 	}
 
 	//Remove punctuation marks and normalize input
@@ -26,15 +26,14 @@ export function validateItemString(
 
 	//Condition 2: check each item from the normalized list against the normalized input for duplicates
 	const isItemOnList = (validatedString: string): boolean => {
-		return normalizedItemNames.some(
-			(item) => item.toLowerCase() === validatedString.toLowerCase(),
-		);
+		return normalizedItemNames.some((item) => item === validatedString);
 	};
 
-	//return validatedString input if no duplicates found
+	//return error if the item already exists
 	if (isItemOnList(validatedString)) {
-		throw new Error("Item already exists");
-	} else {
-		return validatedString;
+		return "Item already exists in the list.";
 	}
+
+	// Return null if no errors are found
+	return null;
 }

--- a/src/utils/validateTrimmedString.ts
+++ b/src/utils/validateTrimmedString.ts
@@ -1,9 +1,9 @@
 import { ListItem } from "../api";
 
-// makes sure the string passed into the function isn't an empty string
-export function validateItemString(
+// Validates the item name input for a shopping list
+export function validateItemName(
 	input: string,
-	itemList: ListItem[],
+	existingItems: ListItem[],
 ): string | null {
 	const trimmedInput = input.trim(); //removes leading and trailing whitespaces
 
@@ -13,27 +13,29 @@ export function validateItemString(
 	}
 
 	//Remove punctuation marks and normalize input
-	const removedPunctuation = /[^\p{L}\s]/gu;
+	const punctuationRegex = /[^\p{L}\s]/gu;
 
-	const validatedString = trimmedInput
-		.replace(removedPunctuation, "")
+	const normalizedInputName = trimmedInput
+		.replace(punctuationRegex, "")
 		.toLowerCase();
 
-	//Create a normalized list of items already present in the list
-	const normalizedItemNames = itemList.map((listItem) => {
-		return listItem.name.replace(removedPunctuation, "").toLowerCase();
+	//Create a list of  normalized existing item names
+	const normalizedExistingItemNames = existingItems.map((existingItem) => {
+		return existingItem.name.replace(punctuationRegex, "").toLowerCase();
 	});
 
-	//Condition 2: check each item from the normalized list against the normalized input for duplicates
-	const isItemOnList = (validatedString: string): boolean => {
-		return normalizedItemNames.some((item) => item === validatedString);
+	// Condition 2: Check if the normalized input matches any existing item
+	const isDuplicateItem = (normalizedInputName: string): boolean => {
+		return normalizedExistingItemNames.some(
+			(item) => item === normalizedInputName,
+		);
 	};
 
 	//return error if the item already exists
-	if (isItemOnList(validatedString)) {
+	if (isDuplicateItem(normalizedInputName)) {
 		return "Item already exists in the list.";
 	}
 
-	// Return null if no errors are found
+	// Return null if no errors are found (input is valid)
 	return null;
 }

--- a/src/views/authenticated/ManageList.tsx
+++ b/src/views/authenticated/ManageList.tsx
@@ -1,17 +1,19 @@
 import { AddItemForm } from "../../components/forms/AddItemForm";
 import ShareListForm from "../../components/forms/ShareListForm";
+import { ListItem } from "../../api";
 
 interface Props {
+	data: ListItem[];
 	listPath: string | null;
 }
 
-export function ManageList({ listPath }: Props) {
+export function ManageList({ listPath, data }: Props) {
 	return (
 		<div>
 			<p>
 				Hello from the <code>/manage-list</code> page!
 			</p>
-			<AddItemForm listPath={listPath} />
+			<AddItemForm listPath={listPath} data={data || []} />
 			<ShareListForm listPath={listPath} />
 		</div>
 	);


### PR DESCRIPTION
## Description

<!-- What does this code change? Why did I choose this approach? Did I learn anything worth sharing? Reminder: This will be a publicly facing representation of your work (READ: help you land that sweet dev gig). -->
Users shouldn't be able to add an empty item to their list, or add the same item twice. If they try to do this, we need to show them an error message that explains the problem. This way, we’ll prevent some clutter in their lists.

## Related Issue

closes #10 

## Acceptance Criteria

- [x]  Show an error message if the user tries to submit an empty item
- [x]  Show an error message if the user tries to submit a new item that is identical to an existing name. For instance, if the list contains apples and the user adds apples.
- [x]  Show an error message if the user tries to submit a new item that matches an existing name with punctuation and casing normalized. For instance, if the list contains apples and the user adds aPples or apples, or a pples.
- [x]  The user’s original input is saved in the database

## Type of Changes

`enhancement` 

## Updates

https://github.com/user-attachments/assets/3061c804-2e60-4d9c-a0f6-db47f800bb59


## Testing Steps / QA Criteria
1. Visit the [preview URL for this PR](https://tcl-77-smart-shopping-list--pr34-ma-fz-duplicate-or-e-7fmtso5p.web.app/)
2. Navigate to ManageList view and add a new Item to the list. 
3. Try to add an empty item, which should show an error message. 
4. Try to add an item that is identical to an item that already exists in the list. This should show an error indicating that the item already exists in the list. 
5. Try to add an item that is similar to an existing item with different casing and punctuation (e.g., if the list already contains `Apples`, try adding `apples` or `aPples` or `a pples`). This should show an error indicating that the item already exists in the list. 
